### PR TITLE
Fix conversationTitle build error

### DIFF
--- a/src/firebase-support.ts
+++ b/src/firebase-support.ts
@@ -40,7 +40,7 @@ export const subscribeFcmNotifications = async (convoClient: Client) => {
 };
 
 export const showNotification = (pushNotification: PushNotification) => {
-  const notificationTitle = pushNotification.data.conversationTitle;
+  const notificationTitle = pushNotification.title;
   const notificationOptions = {
     body: pushNotification.body,
     icon: "favicon.ico",


### PR DESCRIPTION
https://github.com/twilio/twilio-conversations-demo-react/issues/17#issue-1174386957
Reference PushNotification.title instead of PushNotification.data.conversationTitle on the `PushNotification` class:
`@twilio/conversations/builds/lib.d.ts`
```
/**
 * Additional data for a given push notification.
 */
interface PushNotificationData {
    /**
     * SID of the conversation.
     */
    conversationSid?: string;
    /**
     * Index of the message in the conversation.
     */
    messageIndex?: number;
    /**
     * SID of the message in the conversation.
     */
    messageSid?: string;
}
/**
 * Push notification for a Conversations client.
 */
declare class PushNotification {
    /**
     * Title of the notification.
     */
    readonly title: string;
    /**
     * Text of the notification.
     */
    readonly body: string;
    /**
     * Sound of the notification.
     */
    readonly sound: string;
    /**
     * Number of the badge.
     */
    readonly badge: number;
    /**
     * Notification action (`click_action` in FCM terms and `category` in APN terms).
     */
    readonly action: string;
    /**
     * Type of the notification.
     */
    readonly type: PushNotificationType;
    /**
     * Additional data of the conversation.
     */
    readonly data: PushNotificationData;
    /**
     * @internal
     */
    constructor(data: PushNotificationDescriptor);
}
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
