### PR TITLE
RTDSDK-4036 - Use ChatComposer from Paste

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.0",
   "private": true,
   "dependencies": {
+    "@twilio-paste/chat-composer": "^3.0.0",
     "@twilio-paste/core": "19.0.0",
     "@twilio-paste/icons": "11.0.0",
     "@twilio/conversations": "2.4.0-rc.0",

--- a/src/components/message/MessageInput.tsx
+++ b/src/components/message/MessageInput.tsx
@@ -1,108 +1,98 @@
 import { Box } from "@twilio-paste/core";
-import { useState, useLayoutEffect, KeyboardEventHandler } from "react";
+import { ChatComposer } from "@twilio-paste/core/chat-composer";
+import {
+  $getRoot,
+  ClearEditorPlugin,
+  CLEAR_EDITOR_COMMAND,
+  COMMAND_PRIORITY_LOW,
+  EditorState,
+  KEY_ENTER_COMMAND,
+  useLexicalComposerContext,
+} from "@twilio-paste/lexical-library";
+import { useEffect } from "react";
 import MessageFile from "./MessageFile";
 
 interface MessageInputProps {
   message: string;
   onChange: (message: string) => void;
-  onKeyPress: KeyboardEventHandler<HTMLInputElement>;
+  onEnterKeyPress: () => void;
   onFileRemove: (file: string) => void;
   assets: File[];
 }
 
-function useWindowSize() {
-  const [size, setSize] = useState(0);
-  useLayoutEffect(() => {
-    function updateSize() {
-      setSize(window.innerWidth);
-    }
-    window.addEventListener("resize", updateSize);
-    updateSize();
-    return () => window.removeEventListener("resize", updateSize);
-  }, []);
-  return size;
+interface EnterKeyPluginProps {
+  onEnterKeyPress: () => void;
 }
 
-function getTextWidth(text: string) {
-  const canvas = document.createElement("canvas");
-  const context = canvas.getContext("2d");
-  if (context !== null && context !== undefined) {
-    context.font = "14px Inter";
-    return context.measureText(text).width;
-  }
-  return 0;
+const EnterKeyPlugin = (props: EnterKeyPluginProps) => {
+  const { onEnterKeyPress } = props;
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_ENTER_COMMAND,
+      () => {
+        onEnterKeyPress();
+        return true;
+      },
+      COMMAND_PRIORITY_LOW
+    );
+  }, [editor, onEnterKeyPress]);
+
+  return null;
+};
+
+// when message gets cleared and given it's a prop passed in to MessageInput
+// we need to clear the Lexical editor.
+// TODO: there has to be a simpler way of doing a basic binding like this with Lexical
+
+interface MessagePropPluginProps {
+  message: string;
 }
+
+const MessagePropPlugin = (props: MessagePropPluginProps) => {
+  const { message } = props;
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    if (message === undefined || message === null || message.length === 0) {
+      editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
+    }
+  }, [editor, message]);
+
+  return null;
+};
 
 const MessageInput: React.FC<MessageInputProps> = (
   props: MessageInputProps
 ) => {
-  const [cursorPosition, setCursorPostions] = useState<number>(0);
-  const width = useWindowSize();
-  //500 is the width of the rest of the components. So totalWidth-500=widthOfInput
+  const { onEnterKeyPress, message } = props;
+
   return (
     <Box>
-      {getTextWidth(props.message) < width - 500 && (
-        <input
-          type="text"
-          onChange={(e) => {
-            setCursorPostions(e.currentTarget.selectionStart ?? 0);
-            props.onChange(e.currentTarget.value);
+      <Box marginLeft={"space40"}>
+        <ChatComposer
+          config={{
+            namespace: "message-input",
+            onError: (e) => {
+              throw e;
+            },
           }}
-          aria-describedby="message_help_text"
-          id="message-input-shorter"
-          name="message-input-shorter"
-          value={props.message}
-          autoFocus
-          autoComplete="false"
-          autoSave="false"
+          ariaLabel="A basic chat composer"
           placeholder="Add your message"
-          style={{
-            border: props.assets.length ? "none" : "1px solid #8891AA",
-            padding: "8px 12px",
-            height: "36px",
-            margin: `${
-              "0 6px " + (props.assets.length ? "12" : "4") + "px 6px"
-            }`,
-            borderRadius: "4px",
-            width: "100%",
+          onChange={(editorState: EditorState): void => {
+            editorState.read(() => {
+              const text = $getRoot().getTextContent();
+              props.onChange(text);
+            });
           }}
-          onFocus={(e) =>
-            e.currentTarget.setSelectionRange(cursorPosition, cursorPosition)
-          }
-          onKeyPress={props.onKeyPress}
-        />
-      )}
-
-      {getTextWidth(props.message) >= width - 500 && (
-        <textarea
-          onChange={(e) => {
-            setCursorPostions(e.currentTarget.selectionStart);
-            props.onChange(e.currentTarget.value);
-          }}
-          aria-describedby="message_help_text"
-          id="message-input"
-          name="message-input"
-          value={props.message}
-          autoFocus
-          style={{
-            border: props.assets.length ? "none" : "1px solid #8891AA",
-            borderRadius: "4px",
-            width: "100%",
-            padding: "8px 12px",
-            minHeight: "36px",
-            margin: `${
-              "0 6px " + (props.assets.length ? "12" : "4") + "px 6px"
-            }`,
-            fontStyle: "normal",
-            fontSize: "14px",
-            lineHeight: "20px",
-          }}
-          onFocus={(e) =>
-            e.currentTarget.setSelectionRange(cursorPosition, cursorPosition)
-          }
-        />
-      )}
-      {props.assets.length ? (
+        >
+          <ClearEditorPlugin />
+          <MessagePropPlugin message={message} />
+          <EnterKeyPlugin onEnterKeyPress={onEnterKeyPress} />
+        </ChatComposer>
+      </Box>
+      {props.assets.length > 0 && (
         <Box
           style={{
             display: "flex",
@@ -117,7 +107,7 @@ const MessageInput: React.FC<MessageInputProps> = (
             />
           ))}
         </Box>
-      ) : null}
+      )}
     </Box>
   );
 };

--- a/src/components/message/MessageInputField.tsx
+++ b/src/components/message/MessageInputField.tsx
@@ -205,10 +205,8 @@ const MessageInputField: React.FC<SendMessageProps> = (
               sdkConvo.typing();
               setMessage(e);
             }}
-            onKeyPress={async (e) => {
-              if (e.key === "Enter") {
-                await onMessageSend();
-              }
+            onEnterKeyPress={async () => {
+              await onMessageSend();
             }}
             onFileRemove={onFileRemove}
           />


### PR DESCRIPTION
This PR adopts the [ChatComposer](https://paste.twilio.design/components/chat-composer) component introduced in Paste:

<img width="1507" alt="Screenshot 2023-04-04 at 9 33 37 AM" src="https://user-images.githubusercontent.com/97918579/229843700-a243e56c-0b63-4c52-85ef-5524c7a5c406.png">

Send button still appears after typing some text:

<img width="1507" alt="Screenshot 2023-04-04 at 9 33 52 AM" src="https://user-images.githubusercontent.com/97918579/229843820-f152c574-dfea-468d-bb24-f0949f4793f4.png">

Narrow width support:

<img width="614" alt="Screenshot 2023-04-04 at 9 34 15 AM" src="https://user-images.githubusercontent.com/97918579/229843862-eb979175-19f1-4761-9dcc-eb288aee39ca.png">