### PR TITLE
Added the option to run the demo app locally via Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+*
+
+!.eslintrc.json
+!tsconfig.json
+!webpack.config.js
+!.env
+!public/
+!yarn.lock
+!package.json
+!src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:19-alpine
+
+ARG BASE_DIR=/opt/demo-app
+RUN mkdir $BASE_DIR
+
+# All other files are ignored by default via .dockerignore to avoid unnecessarily inflating the Docker context
+# Files and directories are ordered by how frequently they change to maximize the use of Docker cache
+COPY .eslintrc.json $BASE_DIR
+COPY tsconfig.json $BASE_DIR
+COPY webpack.config.js $BASE_DIR
+COPY .env $BASE_DIR
+COPY public $BASE_DIR/public
+COPY yarn.lock $BASE_DIR
+COPY package.json $BASE_DIR
+
+WORKDIR $BASE_DIR
+# Install project dependencies
+RUN yarn
+
+# Expose port 3000 to make the app accessible via the host machine's browser
+EXPOSE 3000
+
+# Start the demo app
+CMD yarn start

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ Select your [conversations service](https://www.twilio.com/console/conversations
 
 ### Run application
 
+Run `docker compose up --build` to build and locally run the application inside a Docker container.
+
+Alternatively,
 - Run `yarn` to fetch project dependencies.
 - Run `yarn start` to run the application locally.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      # Source dir is mounted (instead of copying) to enable Webpack's hot reload feature
+      - "./src:/opt/demo-app/src"


### PR DESCRIPTION
_Please accept this ridiculously late contribution to the Swarm._

This adds the option to run the Conversations demo app locally using Docker and Compose V2.

**Why is this beneficial?** 

It eliminates the overhead of maintaining a local Node environment necessary to run the demo app. Maintaining means running compatible versions of Node, NPM and Yarn.
This may sound trivial, but the number of times I've had to switch between different Node versions, clear Node modules, reinstall and clear the cache of Yarn is higher than I'd ever expected myself.

This small addition should help alleviate similar frustrations of others.

**Risks**

Starting the container does not automatically open the app in the browser, this has to be done manually.

The Webpack Dev Server's hot reload function still works as expected, as the `src` directory from the host machine is mounted into the container. The same can be done for other directories/files if deemed useful.