### PR TITLE
RTDSDK-4106 Add participants avatar bar

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,6 +1,7 @@
 import { Avatar as PasteAvatar } from "@twilio-paste/avatar";
 import { UserIcon } from "@twilio-paste/icons/cjs/UserIcon";
 import { IconSize } from "@twilio-paste/style-props";
+import { Tooltip } from "@twilio-paste/core";
 
 type AvatarProps = {
   name: string;
@@ -23,7 +24,11 @@ const Avatar: React.FC<AvatarProps> = ({ name, size }) => {
       />
     );
   }
-  return <PasteAvatar size={size ?? "sizeIcon70"} variant="user" name={name} />;
+  return (
+    <Tooltip text={name} placement={"bottom-start"}>
+      <PasteAvatar size={size ?? "sizeIcon70"} variant="user" name={name} />
+    </Tooltip>
+  );
   // use src for specified avatar images - once we have them!
 };
 

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -9,11 +9,22 @@ type AvatarProps = {
 
 // name = friendlyName ?? identity
 const Avatar: React.FC<AvatarProps> = ({ name, size }) => {
-	if (name.startsWith("whatsapp:") || name.startsWith("sms:") || name.startsWith("+")) {
-		return <PasteAvatar size={size ?? "sizeIcon70"} variant="user" name={name} icon={UserIcon} />
-	}
-	return <PasteAvatar size={size ?? "sizeIcon70"} variant="user" name={name} />
-	// use src for specified avatar images - once we have them!
+  if (
+    name.startsWith("whatsapp:") ||
+    name.startsWith("sms:") ||
+    name.startsWith("+")
+  ) {
+    return (
+      <PasteAvatar
+        size={size ?? "sizeIcon70"}
+        variant="user"
+        name={name}
+        icon={UserIcon}
+      />
+    );
+  }
+  return <PasteAvatar size={size ?? "sizeIcon70"} variant="user" name={name} />;
+  // use src for specified avatar images - once we have them!
 };
 
 export { Avatar };

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -16,12 +16,14 @@ const Avatar: React.FC<AvatarProps> = ({ name, size }) => {
     name.startsWith("+")
   ) {
     return (
-      <PasteAvatar
-        size={size ?? "sizeIcon70"}
-        variant="user"
-        name={name}
-        icon={UserIcon}
-      />
+      <Tooltip text={name} placement={"bottom-start"}>
+        <PasteAvatar
+          size={size ?? "sizeIcon70"}
+          variant="user"
+          name={name}
+          icon={UserIcon}
+        />
+      </Tooltip>
     );
   }
   return (

--- a/src/components/AvatarGroup.tsx
+++ b/src/components/AvatarGroup.tsx
@@ -1,35 +1,23 @@
 import { AvatarGroup as PasteAvatarGroup } from "@twilio-paste/avatar";
-import { UserIcon } from "@twilio-paste/icons/cjs/UserIcon";
-import { IconSize } from "@twilio-paste/style-props";
 import React from "react";
-import { ReduxParticipant } from "../store/reducers/participantsReducer";
 import Avatar from "./Avatar";
+import { IconSize } from "@twilio-paste/style-props";
 
 type AvatarGroupProps = {
+  names: string[];
+  size?: IconSize;
   maxDisplayed?: number;
-  participants: ReduxParticipant[];
 };
 
-const AvatarGroup: React.FC<AvatarGroupProps> = ({
-  maxDisplayed,
-  participants,
-}) => {
-  const children: JSX.Element[] = participants.map((participant) => {
-    let participantName: string | null = participant.identity;
-    if (participantName == null) {
-      participantName = "placeholder";
-    }
-    return <Avatar name={participantName} />;
-  });
-
+const AvatarGroup: React.FC<AvatarGroupProps> = ({ names, size }) => {
   return (
-    <React.Fragment>
-      <PasteAvatarGroup
-        size={"sizeIcon70"}
-        variant="user"
-        children={children}
-      />
-    </React.Fragment>
+    <PasteAvatarGroup
+      size={"sizeIcon70"}
+      variant="user"
+      children={names.map((name) => (
+        <Avatar name={name} size={size} />
+      ))}
+    />
   );
 };
 

--- a/src/components/AvatarGroup.tsx
+++ b/src/components/AvatarGroup.tsx
@@ -1,18 +1,17 @@
-import { AvatarGroup as PasteAvatarGroup } from "@twilio-paste/avatar";
 import React from "react";
+import { AvatarGroup as PasteAvatarGroup } from "@twilio-paste/avatar";
 import Avatar from "./Avatar";
 import { IconSize } from "@twilio-paste/style-props";
 
 type AvatarGroupProps = {
   names: string[];
   size?: IconSize;
-  maxDisplayed?: number;
 };
 
 const AvatarGroup: React.FC<AvatarGroupProps> = ({ names, size }) => {
   return (
     <PasteAvatarGroup
-      size={"sizeIcon70"}
+      size={size ?? "sizeIcon70"}
       variant="user"
       children={names.map((name) => (
         <Avatar name={name} size={size} />

--- a/src/components/AvatarGroup.tsx
+++ b/src/components/AvatarGroup.tsx
@@ -1,0 +1,37 @@
+import { AvatarGroup as PasteAvatarGroup } from "@twilio-paste/avatar";
+import { UserIcon } from "@twilio-paste/icons/cjs/UserIcon";
+import { IconSize } from "@twilio-paste/style-props";
+import React from "react";
+import { ReduxParticipant } from "../store/reducers/participantsReducer";
+import Avatar from "./Avatar";
+
+type AvatarGroupProps = {
+  maxDisplayed?: number;
+  participants: ReduxParticipant[];
+};
+
+const AvatarGroup: React.FC<AvatarGroupProps> = ({
+  maxDisplayed,
+  participants,
+}) => {
+  const children: JSX.Element[] = participants.map((participant) => {
+    let participantName: string | null = participant.identity;
+    if (participantName == null) {
+      participantName = "placeholder";
+    }
+    return <Avatar name={participantName} />;
+  });
+
+  return (
+    <React.Fragment>
+      <PasteAvatarGroup
+        size={"sizeIcon70"}
+        variant="user"
+        children={children}
+      />
+    </React.Fragment>
+  );
+};
+
+export { AvatarGroup };
+export default AvatarGroup;

--- a/src/components/conversations/ParticipantsView.tsx
+++ b/src/components/conversations/ParticipantsView.tsx
@@ -16,6 +16,20 @@ interface ParticipantsViewProps {
   maxDisplayedParticipants?: number;
 }
 
+function fetchName(participant: ReduxParticipant): string {
+  let name: string = participant.identity ?? "unknown";
+  if (participant.attributes != null) {
+    const friendlyName: string | null =
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      participant.attributes["friendlyName"];
+    if (friendlyName != null) {
+      name = friendlyName;
+    }
+  }
+  return name;
+}
+
 const ParticipantsView: React.FC<ParticipantsViewProps> = (
   props: ParticipantsViewProps
 ) => {
@@ -44,13 +58,14 @@ const ParticipantsView: React.FC<ParticipantsViewProps> = (
 
   const displayedParticipants = [];
   const hiddenParticipants = [];
+
   for (let i = 0; i < props.participants.length; i++) {
     const participant = props.participants[i];
-    const identity = participant.identity ?? " ";
+    const name = fetchName(participant);
     if (i < maxDisplayedParticipants) {
-      displayedParticipants.push(identity);
+      displayedParticipants.push(name);
     } else {
-      hiddenParticipants.push(identity);
+      hiddenParticipants.push(name);
     }
 
     if (i == MAX_HIDDEN_PARTICIPANTS - 1) {

--- a/src/components/conversations/ParticipantsView.tsx
+++ b/src/components/conversations/ParticipantsView.tsx
@@ -3,6 +3,8 @@ import { Button } from "@twilio-paste/button";
 import { PlusIcon } from "@twilio-paste/icons/esm/PlusIcon";
 import { ReduxParticipant } from "../../store/reducers/participantsReducer";
 import styles from "../../styles";
+import AvatarGroup from "../AvatarGroup";
+import Avatar from "../Avatar";
 
 interface ParticipantsViewProps {
   participants: ReduxParticipant[];
@@ -16,7 +18,11 @@ const ParticipantsView: React.FC<ParticipantsViewProps> = (
     return (
       <>
         <Box style={styles.addParticipantsButton}>
-          <Button fullWidth variant="secondary" onClick={props.onParticipantListOpen}>
+          <Button
+            fullWidth
+            variant="secondary"
+            onClick={props.onParticipantListOpen}
+          >
             <PlusIcon decorative={false} title="Add participants" />
             {"Add participants"}
           </Button>
@@ -25,23 +31,15 @@ const ParticipantsView: React.FC<ParticipantsViewProps> = (
     );
   }
 
+  const participantAvatars: JSX.Element[] = props.participants.map(
+    (participant) => {
+      return <Avatar name={participant.identity ?? " "} />;
+    }
+  );
+
   return (
     <>
-      <Box
-        style={{
-          height: "100%",
-          display: "flex",
-          alignItems: "center",
-        }}
-        color="colorTextWeak"
-        fontFamily="fontFamilyText"
-        fontSize="fontSize30"
-        lineHeight="lineHeight40"
-        fontWeight="fontWeightNormal"
-        paddingRight="space60"
-      >
-        {`${props.participants.length} participants`}
-      </Box>
+      <AvatarGroup participants={props.participants} />
     </>
   );
 };

--- a/src/components/conversations/ParticipantsView.tsx
+++ b/src/components/conversations/ParticipantsView.tsx
@@ -66,7 +66,9 @@ const ParticipantsView: React.FC<ParticipantsViewProps> = (
         orientation={["vertical", "horizontal", "horizontal"]}
         spacing="space30"
       >
-        <AvatarGroup names={displayedParticipants} />
+        <Button variant={"reset"} onClick={props.onParticipantListOpen}>
+          <AvatarGroup names={displayedParticipants} />
+        </Button>
         {hiddenParticipants.length > 0 ? (
           <Tooltip
             text={hiddenParticipants.join(", ")}

--- a/src/components/conversations/ParticipantsView.tsx
+++ b/src/components/conversations/ParticipantsView.tsx
@@ -1,14 +1,23 @@
-import { Box } from "@twilio-paste/core";
+import {
+  Box,
+  Popover,
+  PopoverButton,
+  PopoverContainer,
+  Stack,
+  Tooltip,
+} from "@twilio-paste/core";
 import { Button } from "@twilio-paste/button";
 import { PlusIcon } from "@twilio-paste/icons/esm/PlusIcon";
 import { ReduxParticipant } from "../../store/reducers/participantsReducer";
 import styles from "../../styles";
 import AvatarGroup from "../AvatarGroup";
-import Avatar from "../Avatar";
+
+const MAX_DISPLAYED_PARTICIPANTS = 5;
 
 interface ParticipantsViewProps {
   participants: ReduxParticipant[];
   onParticipantListOpen: () => void;
+  maxDisplayedParticipants?: number;
 }
 
 const ParticipantsView: React.FC<ParticipantsViewProps> = (
@@ -31,15 +40,20 @@ const ParticipantsView: React.FC<ParticipantsViewProps> = (
     );
   }
 
-  const participantAvatars: JSX.Element[] = props.participants.map(
-    (participant) => {
-      return <Avatar name={participant.identity ?? " "} />;
-    }
-  );
-
   return (
     <>
-      <AvatarGroup participants={props.participants} />
+      <Stack orientation="horizontal" spacing="space10">
+        <AvatarGroup
+          names={props.participants.map(
+            (participant) => participant.identity ?? " "
+          )}
+        />
+        <Tooltip text={"Bottom Text"} placement={"bottom-start"}>
+          <Button variant="link" size={"small"}>
+            and N other Participants
+          </Button>
+        </Tooltip>
+      </Stack>
     </>
   );
 };

--- a/src/components/conversations/ParticipantsView.tsx
+++ b/src/components/conversations/ParticipantsView.tsx
@@ -1,21 +1,14 @@
-import {
-  Box,
-  Popover,
-  PopoverButton,
-  PopoverContainer,
-  Stack,
-  Tooltip,
-  Text,
-} from "@twilio-paste/core";
+import React from "react";
+import { Box, Stack, Tooltip } from "@twilio-paste/core";
 import { Button } from "@twilio-paste/button";
 import { PlusIcon } from "@twilio-paste/icons/esm/PlusIcon";
+import { useTheme } from "@twilio-paste/theme";
 import { ReduxParticipant } from "../../store/reducers/participantsReducer";
 import styles from "../../styles";
 import AvatarGroup from "../AvatarGroup";
-import { useTheme } from "@twilio-paste/theme";
-import React from "react";
 
 const DEFAULT_MAX_DISPLAYED_PARTICIPANTS = 5;
+const MAX_HIDDEN_PARTICIPANTS = 50;
 
 interface ParticipantsViewProps {
   participants: ReduxParticipant[];
@@ -26,7 +19,6 @@ interface ParticipantsViewProps {
 const ParticipantsView: React.FC<ParticipantsViewProps> = (
   props: ParticipantsViewProps
 ) => {
-  const theme = useTheme();
   if (props.participants.length == 1) {
     return (
       <>
@@ -44,6 +36,9 @@ const ParticipantsView: React.FC<ParticipantsViewProps> = (
     );
   }
 
+  const theme = useTheme();
+  // Display only a limited number of participant avatars
+  // Hide the rest behind a text element with a tooltip
   const maxDisplayedParticipants =
     props.maxDisplayedParticipants ?? DEFAULT_MAX_DISPLAYED_PARTICIPANTS;
 
@@ -57,11 +52,20 @@ const ParticipantsView: React.FC<ParticipantsViewProps> = (
     } else {
       hiddenParticipants.push(identity);
     }
+
+    if (i == MAX_HIDDEN_PARTICIPANTS - 1) {
+      // Limit hidden participants too, as we don't want the tooltip to grow up to 1000+ participants large
+      hiddenParticipants.push("...");
+      break;
+    }
   }
 
   return (
     <>
-      <Stack orientation="horizontal" spacing="space30">
+      <Stack
+        orientation={["vertical", "horizontal", "horizontal"]}
+        spacing="space30"
+      >
         <AvatarGroup names={displayedParticipants} />
         {hiddenParticipants.length > 0 ? (
           <Tooltip

--- a/src/components/conversations/ParticipantsView.tsx
+++ b/src/components/conversations/ParticipantsView.tsx
@@ -5,14 +5,17 @@ import {
   PopoverContainer,
   Stack,
   Tooltip,
+  Text,
 } from "@twilio-paste/core";
 import { Button } from "@twilio-paste/button";
 import { PlusIcon } from "@twilio-paste/icons/esm/PlusIcon";
 import { ReduxParticipant } from "../../store/reducers/participantsReducer";
 import styles from "../../styles";
 import AvatarGroup from "../AvatarGroup";
+import { useTheme } from "@twilio-paste/theme";
+import React from "react";
 
-const MAX_DISPLAYED_PARTICIPANTS = 5;
+const DEFAULT_MAX_DISPLAYED_PARTICIPANTS = 5;
 
 interface ParticipantsViewProps {
   participants: ReduxParticipant[];
@@ -23,6 +26,7 @@ interface ParticipantsViewProps {
 const ParticipantsView: React.FC<ParticipantsViewProps> = (
   props: ParticipantsViewProps
 ) => {
+  const theme = useTheme();
   if (props.participants.length == 1) {
     return (
       <>
@@ -40,19 +44,42 @@ const ParticipantsView: React.FC<ParticipantsViewProps> = (
     );
   }
 
+  const maxDisplayedParticipants =
+    props.maxDisplayedParticipants ?? DEFAULT_MAX_DISPLAYED_PARTICIPANTS;
+
+  const displayedParticipants = [];
+  const hiddenParticipants = [];
+  for (let i = 0; i < props.participants.length; i++) {
+    const participant = props.participants[i];
+    const identity = participant.identity ?? " ";
+    if (i < maxDisplayedParticipants) {
+      displayedParticipants.push(identity);
+    } else {
+      hiddenParticipants.push(identity);
+    }
+  }
+
   return (
     <>
-      <Stack orientation="horizontal" spacing="space10">
-        <AvatarGroup
-          names={props.participants.map(
-            (participant) => participant.identity ?? " "
-          )}
-        />
-        <Tooltip text={"Bottom Text"} placement={"bottom-start"}>
-          <Button variant="link" size={"small"}>
-            and N other Participants
-          </Button>
-        </Tooltip>
+      <Stack orientation="horizontal" spacing="space30">
+        <AvatarGroup names={displayedParticipants} />
+        {hiddenParticipants.length > 0 ? (
+          <Tooltip
+            text={hiddenParticipants.join(", ")}
+            placement={"bottom-start"}
+          >
+            <span
+              style={{
+                verticalAlign: "top",
+                paddingRight: 10,
+                color: theme.textColors.colorText,
+                fontWeight: theme.fontWeights.fontWeightSemibold,
+              }}
+            >
+              and {hiddenParticipants.length} other Participants
+            </span>
+          </Tooltip>
+        ) : null}
       </Stack>
     </>
   );


### PR DESCRIPTION
This change adds the participants avatar bar to the demo app. Up to 5 avatars are displayed by default, if the conversation has more than 5 participants then the rest of the participants are hidden away in a text hint.
Both the avatars and the text hint display a tooltip of the participant name. 

Clicking the avatars opens the "Manage participants" modal.

The avatars within the avatar group display the `identity` of the participants; this does mean that non-chat participants have effectively no avatar. This needs to be changed in a future PR.

A few screenshots of how this looks:

<img width="1440" alt="image" src="https://github.com/twilio/twilio-conversations-demo-react/assets/89582386/b75aa915-5106-4f01-b3fc-f406a46350a6">

<img width="1440" alt="image" src="https://github.com/twilio/twilio-conversations-demo-react/assets/89582386/764d5c3d-3fb8-48f1-ba7b-8105a01c332b">

<img width="1440" alt="image" src="https://github.com/twilio/twilio-conversations-demo-react/assets/89582386/4737c9d6-8176-4471-8c13-0d407292d3ba">

