### PR TITLE
feat: Add unread messages counter to page title

### DIFF
--- a/src/components/conversations/ConversationsList.tsx
+++ b/src/components/conversations/ConversationsList.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect } from "react";
 import { bindActionCreators } from "redux";
 import { useDispatch, useSelector } from "react-redux";
 import ConversationView from "./ConversationView";
@@ -85,6 +86,17 @@ const ConversationsList: React.FC = () => {
   if (conversations === undefined || conversations === null) {
     return <div className="empty" />;
   }
+
+  useEffect(() => {
+    const sum = Object.values(unreadMessages).reduce(
+      (acc, value) => acc + value,
+      0
+    );
+    document.title =
+      sum >= 1 ? `(${sum}) Conversations Demo` : "Conversations Demo";
+
+    return () => new AbortController().abort();
+  }, [unreadMessages]);
 
   return (
     <div id="conversation-list">


### PR DESCRIPTION
This PR implements a feature that dynamically updates the page title to display the number of unread messages in the Conversations Demo app. When there are unread messages, the title will show "(X) Conversations Demo" where X represents the count. If there are no unread messages, the title reverts to "Conversations Demo".

<img width="518" alt="image" src="https://github.com/twilio/twilio-conversations-demo-react/assets/51721338/8835990b-b060-4ec8-a336-bcfb0cc4c681">

This enhancement aims to improve the user experience by providing a visual cue for unread messages even when the user is not actively on the application tab.

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ x] I acknowledge that all my contributions will be made under the project's license.
