### PR TITLE
feat: Edit Icon for Conversation Name

### DIFF
--- a/src/components/conversations/ConversationDetails.tsx
+++ b/src/components/conversations/ConversationDetails.tsx
@@ -1,5 +1,6 @@
 import { Box, Input } from "@twilio-paste/core";
 import { useTheme } from "@twilio-paste/theme";
+import { EditIcon } from "@twilio-paste/icons/esm/EditIcon";
 
 import ParticipantsView from "./ParticipantsView";
 import Settings from "../settings/Settings";
@@ -109,6 +110,7 @@ const ConversationDetails: React.FC<ConversationDetailsProps> = (
           ) : (
             <>{props.convo.friendlyName ?? props.convo.sid}</>
           )}
+          <EditIcon decorative={false} title="Edit conversation name" />
         </Box>
         <Box
           style={{


### PR DESCRIPTION
The conversation name is editable by clicking on it, but it's not clear that it is possible. This PR adds a small pencil / edit icon next to it to indicate that action.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
